### PR TITLE
fix: use `trailerId` in `getVehicleDetailsByTrailerId`

### DIFF
--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -102,7 +102,7 @@ async function getVehicleDetailsByTrailerId(
 ): Promise<VehicleDetails> {
   console.info('Using get by Trailer ID');
   const vehicleDetailsQueryResult = await databaseService.get(technicalQueries.VEHICLE_DETAILS_TRAILER_ID_QUERY, [
-    event.vinNumber,
+    event.trailerId,
   ]);
   return getVehicleDetails(vehicleDetailsQueryResult, databaseService);
 }

--- a/tests/unit/app/databaseService.test.ts
+++ b/tests/unit/app/databaseService.test.ts
@@ -23,7 +23,7 @@ describe('Database Service', () => {
 
       await getVehicleDetailsByVrm(mockDbService, event);
 
-      expect(mockDbService.get.mock.calls[0][0]).toEqual(technicalQueries.VEHICLE_DETAILS_VRM_QUERY);
+      expect(mockDbService.get).toBeCalledWith(technicalQueries.VEHICLE_DETAILS_VRM_QUERY, expect.arrayContaining([event.VehicleRegMark]));
     });
 
     it('passes the expected SQL query to the infrastructure DB service for get by VIN', async () => {
@@ -37,7 +37,7 @@ describe('Database Service', () => {
 
       await getVehicleDetailsByVin(mockDbService, event);
 
-      expect(mockDbService.get.mock.calls[0][0]).toEqual(technicalQueries.VEHICLE_DETAILS_VIN_QUERY);
+      expect(mockDbService.get).toBeCalledWith(technicalQueries.VEHICLE_DETAILS_VIN_QUERY, expect.arrayContaining([event.vinNumber]));
     });
 
     it('passes the expected SQL query to the infrastructure DB service for get by trailer ID', async () => {
@@ -51,7 +51,7 @@ describe('Database Service', () => {
 
       await getVehicleDetailsByTrailerId(mockDbService, event);
 
-      expect(mockDbService.get.mock.calls[0][0]).toEqual(technicalQueries.VEHICLE_DETAILS_TRAILER_ID_QUERY);
+      expect(mockDbService.get).toBeCalledWith(technicalQueries.VEHICLE_DETAILS_TRAILER_ID_QUERY, expect.arrayContaining([event.trailerId]));
     });
 
     it('throws if there is no result from getting the vehicle', async () => {


### PR DESCRIPTION
## Ticket title
Fix `getVehicleDetailsByTrailerId` using the `vinNumber` instead of `trailerId`.
Extend the unit tests to provide failing tests for the above.

## Checklist
- [x] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number