### PR TITLE
feature(cb2-7228), fix(cb2-7420): prevent duplicate vrms in evl file

### DIFF
--- a/src/app/queries/evlQuery.ts
+++ b/src/app/queries/evlQuery.ts
@@ -4,7 +4,7 @@ FROM (
     SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) AS row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
     FROM evl_view
 ) as SubQ
-WHERE row_number_over_partition = 0
+WHERE row_number_over_partition = 0;
 `
 
 const EVL_VRM_QUERY = `${EVL_QUERY} WHERE vrm_trm = ?;`;

--- a/src/app/queries/evlQuery.ts
+++ b/src/app/queries/evlQuery.ts
@@ -4,9 +4,9 @@ FROM (
     SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) AS row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
     FROM evl_view
 ) as SubQ
-WHERE row_number_over_partition = 0;
+WHERE row_number_over_partition = 0
 `
 
-const EVL_VRM_QUERY = `${EVL_QUERY} WHERE vrm_trm = ?;`;
+const EVL_VRM_QUERY = `${EVL_QUERY} AND vrm_trm = ?;`;
 
 export { EVL_QUERY, EVL_VRM_QUERY };

--- a/src/app/queries/evlQuery.ts
+++ b/src/app/queries/evlQuery.ts
@@ -1,44 +1,10 @@
 const EVL_QUERY = `
-SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`
+SELECT testExpiryDate, vrm_trm, certificateNumber
 FROM (
-    SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`, IF(@prev <> \`vrm_trm\`, @rn:=0,@rn) AS \`row_number_over_partition\`, @prev:=\`vrm_trm\`, @rn:=@rn+1 AS \`rn\`
-    FROM ( 
-        SELECT MAX(\`testExpiryDate\`) AS \`testExpiryDate\`,
-            \`SubQ\`.\`vrm_trm\`,
-            \`t\`.\`certificateNumber\`,
-            \`t\`.\`testTypeEndTimeStamp\`
-        FROM \`test_result\` AS \`t\`
-            JOIN \`test_type\` \`tt\` ON \`t\`.\`test_type_id\` = \`tt\`.\`id\`
-            JOIN (
-                SELECT MAX(\`createdAt\`),
-                    \`id\`,
-                    \`vrm_trm\`
-                FROM \`vehicle\`
-                WHERE LENGTH(\`vrm_trm\`) < 8
-                    AND \`vrm_trm\` NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-                    AND \`vrm_trm\` NOT REGEXP '^[0-9]{6}[zZ]$'
-                GROUP BY \`id\`,
-                    \`vrm_trm\`
-            ) \`SubQ\` ON \`SubQ\`.\`id\` = \`t\`.\`vehicle_id\`
-        WHERE \`t\`.\`testExpiryDate\` > DATE(NOW() - INTERVAL 3 DAY)
-                        AND (
-                            \`t\`.\`certificateNumber\` IS NOT NULL
-                            AND \`t\`.\`certificateNumber\` != ''
-                            AND NOT LOCATE(' ', \`t\`.\`certificateNumber\`) > 0
-                        )
-            AND (
-                \`t\`.\`certificateNumber\` IS NOT NULL
-                AND \`t\`.\`certificateNumber\` != ''
-                AND NOT LOCATE(' ', \`t\`.\`certificateNumber\`) > 0
-            )
-            AND \`tt\`.\`testTypeClassification\` = 'Annual With Certificate'
-        GROUP BY \`SubQ\`.\`vrm_trm\`,
-            \`t\`.\`certificateNumber\`,
-            \`t\`.\`testTypeEndTimeStamp\`
-        ORDER BY \`vrm_trm\`, \`testExpiryDate\` desc, \`t\`.\`testTypeEndTimeStamp\` desc
-    ) as \`SubQ2\`
-) as \`SubQ3\`
-WHERE \`row_number_over_partition\` = 0
+    SELECT testExpiryDate, vrm_trm, certificateNumber, IF(@prev <> vrm_trm, @rn:=0,@rn) AS row_number_over_partition, @prev:=vrm_trm, @rn:=@rn+1 AS rn
+    FROM evl_view
+) as SubQ
+WHERE row_number_over_partition = 0
 `
 
 const EVL_VRM_QUERY = `${EVL_QUERY} WHERE vrm_trm = ?;`;

--- a/src/app/queries/evlQuery.ts
+++ b/src/app/queries/evlQuery.ts
@@ -1,26 +1,26 @@
 const EVL_QUERY = `
 SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`
 FROM (
-	SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`, IF(@prev <> \`vrm_trm\`, @rn:=0,@rn) AS \`row_number_over_partition\`, @prev:=\`vrm_trm\`, @rn:=@rn+1 AS \`rn\`
-	FROM ( 
-		SELECT MAX(\`testExpiryDate\`) AS \`testExpiryDate\`,
-			\`SubQ\`.\`vrm_trm\`,
-			\`t\`.\`certificateNumber\`,
-			\`t\`.\`testTypeEndTimeStamp\`
-		FROM \`test_result\` AS \`t\`
-			JOIN \`test_type\` \`tt\` ON \`t\`.\`test_type_id\` = \`tt\`.\`id\`
-			JOIN (
-				SELECT MAX(\`createdAt\`),
-					\`id\`,
-					\`vrm_trm\`
-				FROM \`vehicle\`
-				WHERE LENGTH(\`vrm_trm\`) < 8
-					AND \`vrm_trm\` NOT REGEXP '^[a-zA-Z][0-9]{6}$'
-					AND \`vrm_trm\` NOT REGEXP '^[0-9]{6}[zZ]$'
-				GROUP BY \`id\`,
-					\`vrm_trm\`
-			) \`SubQ\` ON \`SubQ\`.\`id\` = \`t\`.\`vehicle_id\`
-		WHERE \`t\`.\`testExpiryDate\` > DATE(NOW() - INTERVAL 3 DAY)
+    SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`, IF(@prev <> \`vrm_trm\`, @rn:=0,@rn) AS \`row_number_over_partition\`, @prev:=\`vrm_trm\`, @rn:=@rn+1 AS \`rn\`
+    FROM ( 
+        SELECT MAX(\`testExpiryDate\`) AS \`testExpiryDate\`,
+            \`SubQ\`.\`vrm_trm\`,
+            \`t\`.\`certificateNumber\`,
+            \`t\`.\`testTypeEndTimeStamp\`
+        FROM \`test_result\` AS \`t\`
+            JOIN \`test_type\` \`tt\` ON \`t\`.\`test_type_id\` = \`tt\`.\`id\`
+            JOIN (
+                SELECT MAX(\`createdAt\`),
+                    \`id\`,
+                    \`vrm_trm\`
+                FROM \`vehicle\`
+                WHERE LENGTH(\`vrm_trm\`) < 8
+                    AND \`vrm_trm\` NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+                    AND \`vrm_trm\` NOT REGEXP '^[0-9]{6}[zZ]$'
+                GROUP BY \`id\`,
+                    \`vrm_trm\`
+            ) \`SubQ\` ON \`SubQ\`.\`id\` = \`t\`.\`vehicle_id\`
+        WHERE \`t\`.\`testExpiryDate\` > DATE(NOW() - INTERVAL 3 DAY)
                         AND (
                             \`t\`.\`certificateNumber\` IS NOT NULL
                             AND \`t\`.\`certificateNumber\` != ''
@@ -31,12 +31,12 @@ FROM (
                 AND \`t\`.\`certificateNumber\` != ''
                 AND NOT LOCATE(' ', \`t\`.\`certificateNumber\`) > 0
             )
-			AND \`tt\`.\`testTypeClassification\` = 'Annual With Certificate'
-		GROUP BY \`SubQ\`.\`vrm_trm\`,
-			\`t\`.\`certificateNumber\`,
-			\`t\`.\`testTypeEndTimeStamp\`
-		ORDER BY \`vrm_trm\`, \`testExpiryDate\` desc, \`t\`.\`testTypeEndTimeStamp\` desc
-	) as \`SubQ2\`
+            AND \`tt\`.\`testTypeClassification\` = 'Annual With Certificate'
+        GROUP BY \`SubQ\`.\`vrm_trm\`,
+            \`t\`.\`certificateNumber\`,
+            \`t\`.\`testTypeEndTimeStamp\`
+        ORDER BY \`vrm_trm\`, \`testExpiryDate\` desc, \`t\`.\`testTypeEndTimeStamp\` desc
+    ) as \`SubQ2\`
 ) as \`SubQ3\`
 WHERE \`row_number_over_partition\` = 0
 `

--- a/src/app/queries/evlQuery.ts
+++ b/src/app/queries/evlQuery.ts
@@ -1,4 +1,45 @@
-const EVL_QUERY = 'SELECT `testExpiryDate`, `vrm_trm`, `certificateNumber` FROM `evl_view`';
+const EVL_QUERY = `
+SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`
+FROM (
+	SELECT \`testExpiryDate\`, \`vrm_trm\`, \`certificateNumber\`, IF(@prev <> \`vrm_trm\`, @rn:=0,@rn) AS \`row_number_over_partition\`, @prev:=\`vrm_trm\`, @rn:=@rn+1 AS \`rn\`
+	FROM ( 
+		SELECT MAX(\`testExpiryDate\`) AS \`testExpiryDate\`,
+			\`SubQ\`.\`vrm_trm\`,
+			\`t\`.\`certificateNumber\`,
+			\`t\`.\`testTypeEndTimeStamp\`
+		FROM \`test_result\` AS \`t\`
+			JOIN \`test_type\` \`tt\` ON \`t\`.\`test_type_id\` = \`tt\`.\`id\`
+			JOIN (
+				SELECT MAX(\`createdAt\`),
+					\`id\`,
+					\`vrm_trm\`
+				FROM \`vehicle\`
+				WHERE LENGTH(\`vrm_trm\`) < 8
+					AND \`vrm_trm\` NOT REGEXP '^[a-zA-Z][0-9]{6}$'
+					AND \`vrm_trm\` NOT REGEXP '^[0-9]{6}[zZ]$'
+				GROUP BY \`id\`,
+					\`vrm_trm\`
+			) \`SubQ\` ON \`SubQ\`.\`id\` = \`t\`.\`vehicle_id\`
+		WHERE \`t\`.\`testExpiryDate\` > DATE(NOW() - INTERVAL 3 DAY)
+                        AND (
+                            \`t\`.\`certificateNumber\` IS NOT NULL
+                            AND \`t\`.\`certificateNumber\` != ''
+                            AND NOT LOCATE(' ', \`t\`.\`certificateNumber\`) > 0
+                        )
+            AND (
+                \`t\`.\`certificateNumber\` IS NOT NULL
+                AND \`t\`.\`certificateNumber\` != ''
+                AND NOT LOCATE(' ', \`t\`.\`certificateNumber\`) > 0
+            )
+			AND \`tt\`.\`testTypeClassification\` = 'Annual With Certificate'
+		GROUP BY \`SubQ\`.\`vrm_trm\`,
+			\`t\`.\`certificateNumber\`,
+			\`t\`.\`testTypeEndTimeStamp\`
+		ORDER BY \`vrm_trm\`, \`testExpiryDate\` desc, \`t\`.\`testTypeEndTimeStamp\` desc
+	) as \`SubQ2\`
+) as \`SubQ3\`
+WHERE \`row_number_over_partition\` = 0
+`
 
 const EVL_VRM_QUERY = `${EVL_QUERY} WHERE vrm_trm = ?;`;
 


### PR DESCRIPTION
## Ticket title
Update the EVL query to remove duplicate Vrms. The evl view cannot be updated to remove the duplicate Vrms for reasons detailed in https://github.com/dvsa/cvs-nop/pull/8, so this has to be done in this lambda. Will have to update this PR once https://github.com/dvsa/cvs-nop/pull/8 gets merged to update the git submodule, dismissing reviews.

Related issues: 
- [CB2-7228](https://dvsa.atlassian.net/browse/CB2-7228)
- [CB2-7420](https://dvsa.atlassian.net/browse/CB2-7420)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number