### PR TITLE
feat(cb2-4693): improve enquiry service efficiency - update to connection pooling

### DIFF
--- a/src/infrastructure/databaseService.ts
+++ b/src/infrastructure/databaseService.ts
@@ -1,20 +1,17 @@
-import mysqlp, { FieldPacket, RowDataPacket, Connection } from 'mysql2/promise';
+import mysqlp, { FieldPacket, RowDataPacket } from 'mysql2/promise';
 import SecretsManagerServiceInterface from '../interfaces/SecretsManagerService';
 import DatabaseServiceInterface from '../interfaces/DatabaseService';
 
 export default class DatabaseService implements DatabaseServiceInterface {
-  connection: Connection;
-
-  constructor(connection: Connection) {
-    this.connection = connection;
+  public constructor(pool:mysqlp.Pool) {
+    this.pool = pool;
   }
 
   async get(query: string, params: string[] | undefined): Promise<[RowDataPacket[], FieldPacket[]]> {
     try {
       console.info(`Executing query ${query} with params ${params.join(', ')}`);
-      const result = await this.connection.execute<RowDataPacket[]>(query, params);
-
-      return result;
+      const tempResult = await this.pool.query(query, params);
+      return tempResult as [RowDataPacket[], FieldPacket[]];
     } catch (e) {
       // Type checking because the type of e can't be specified in the params
       if (e instanceof Error) {
@@ -25,21 +22,28 @@ export default class DatabaseService implements DatabaseServiceInterface {
     }
   }
 
+  pool:mysqlp.Pool;
+
+  static pool:mysqlp.Pool = undefined;
+
   public static async build(
     secretsManager: SecretsManagerServiceInterface,
     mysql: typeof mysqlp,
   ): Promise<DatabaseServiceInterface> {
     const dbConnectionDetailsString = await secretsManager.getSecret(process.env.SECRET);
     const dbConnectionDetails = JSON.parse(dbConnectionDetailsString) as StoredConnectionDetails;
-    const connection = await mysql.createConnection({
-      user: dbConnectionDetails.username,
-      password: dbConnectionDetails.password,
-      host: dbConnectionDetails.host,
-      port: dbConnectionDetails.port,
-      database: process.env.SCHEMA_NAME,
-    });
+    if (this.pool === undefined) {
+      this.pool = mysql.createPool(<mysqlp.PoolOptions>{
+        connectionLimit: 50,
+        user: dbConnectionDetails.username,
+        password: dbConnectionDetails.password,
+        host: dbConnectionDetails.host,
+        port: dbConnectionDetails.port,
+        database: process.env.SCHEMA_NAME,
+      });
+    }
 
-    return new DatabaseService(connection);
+    return new DatabaseService(this.pool);
   }
 }
 

--- a/src/interfaces/DatabaseService.ts
+++ b/src/interfaces/DatabaseService.ts
@@ -1,5 +1,7 @@
-import { FieldPacket, RowDataPacket } from 'mysql2';
+import { FieldPacket, RowDataPacket } from 'mysql2/promise';
+
+export type QueryOutput = [RowDataPacket[], FieldPacket[]];
 
 export default interface DatabaseService {
-  get(query: string, params: string[] | undefined): Promise<[RowDataPacket[], FieldPacket[]]>;
+  get(query: string, params: string[] | undefined): Promise<[RowDataPacket[], FieldPacket[]]>
 }

--- a/src/resources/localDatabase.ts
+++ b/src/resources/localDatabase.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'child_process';
 const port = 3306;
 const databaseName = 'CVSBNOP';
 const containerName = 'mysql-test-jenkins';
-const rootPassword = '12345';
+const rootPassword = 'password';
 const rootUsername = 'root';
 
 function runCommand(command: string, options: string[]): string {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,7 +3,9 @@ import { createLogger, format, transports } from 'winston';
 const { printf } = format;
 
 // Checks if log is an error - has stack info
-const logFormat = printf((info) => (info.stack ? `${info.level}: ${info.stack as string}` : `${info.level}: ${info.message as string}`));
+const logFormat = printf((info) => (info.stack
+  ? `${info.level}: ${info.stack as string}`
+  : `${info.level}: ${info.message as string}`));
 
 const loggerConfig = {
   level: process.env.LOG_LEVEL || 'info',

--- a/tests/unit/app/databaseService.test.ts
+++ b/tests/unit/app/databaseService.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../src/app/databaseService';
 import * as technicalQueries from '../../../src/app/queries/technicalRecord';
 import * as testQueries from '../../../src/app/queries/testResults';
+import { QueryOutput } from '../../../src/interfaces/DatabaseService';
 
 describe('Database Service', () => {
   describe('Get vehicle details', () => {
@@ -51,7 +52,7 @@ describe('Database Service', () => {
     it('passes the expected SQL query to the infrastructure DB service for get by VRM', async () => {
       const mockDbService = {
         get: jest
-          .fn<Promise<[RowDataPacket[], FieldPacket[]]>, [query: string, params: string[]]>()
+          .fn<Promise<QueryOutput>, [query: string, params: string[]]>()
           .mockResolvedValue([[{ id: '1', result: {} } as RowDataPacket], []]),
       };
 

--- a/tests/unit/infrastructure/databaseService.test.ts
+++ b/tests/unit/infrastructure/databaseService.test.ts
@@ -1,5 +1,6 @@
 import mysqlp from 'mysql2/promise';
 import DatabaseService from '../../../src/infrastructure/databaseService';
+import { QueryOutput } from '../../../src/interfaces/DatabaseService';
 
 describe('Database Service', () => {
   const connectionDetails = {
@@ -24,15 +25,15 @@ describe('Database Service', () => {
   });
 
   it('should throw an error when the query fails', async () => {
-    const mockConnection = ({ execute: jest.fn().mockRejectedValue(new Error()) } as unknown) as mysqlp.Connection;
-    const dbService = new DatabaseService(mockConnection);
+    const mockQuery = jest.fn().mockRejectedValue(new Error()) as (query:string, params:string[] | undefined)=>Promise<QueryOutput>;
+    const dbService = new DatabaseService(<mysqlp.Pool><unknown>{ query: mockQuery });
 
     await expect(dbService.get('sdfsdf', [''])).rejects.toThrow(Error);
   });
 
   it('adds the expected prefix to the error', async () => {
-    const mockConnection = ({ execute: jest.fn().mockRejectedValue(new Error()) } as unknown) as mysqlp.Connection;
-    const dbService = new DatabaseService(mockConnection);
+    const mockQuery = jest.fn().mockRejectedValue(new Error()) as (query:string, params:string[] | undefined)=>Promise<QueryOutput>;
+    const dbService = new DatabaseService(<mysqlp.Pool><unknown>{ query: mockQuery });
 
     await expect(dbService.get('sdfsdf', [''])).rejects.toThrowError('Database error: ');
   });
@@ -42,7 +43,7 @@ describe('Database Service', () => {
       getSecret: jest.fn().mockResolvedValueOnce(JSON.stringify(connectionDetails)).mockResolvedValue('dbName'),
     };
     const mockMysql = ({
-      createConnection: jest.fn().mockResolvedValue({ execute: jest.fn() }),
+      createPool: jest.fn().mockResolvedValue({ execute: jest.fn() }),
     } as unknown) as typeof mysqlp;
 
     await DatabaseService.build(mockSecretsManager, mockMysql);
@@ -51,8 +52,8 @@ describe('Database Service', () => {
   });
 
   it('returns the response from executing the DB query', async () => {
-    const mockConnection = ({ execute: jest.fn().mockReturnValue('Success') } as unknown) as mysqlp.Connection;
-    const dbService = new DatabaseService(mockConnection);
+    const mockQuery = jest.fn().mockReturnValue('Success') as (query:string, params:string[] | undefined)=>Promise<QueryOutput>;
+    const dbService = new DatabaseService(<mysqlp.Pool><unknown>{ query: mockQuery });
     const response = await dbService.get('sdfsdf', ['']);
 
     expect(response).toEqual('Success');


### PR DESCRIPTION
Moved to connection pool queries.

Supercedes the old connection pooling PR as this one had to be deployed to a feature branch to ensure it worked correctly.

Screenshot from working enquiry service call (using infrastructure 4694 - a clone of this code after some TF issues meant we couldn't deploy 4693)

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/87019270/217824574-92289067-fd77-4222-9138-65858d48bf63.png">
