### PR TITLE
feat(cb2-8313): update service to use TFL view

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,7 +29,7 @@ const config: Config.InitialOptions = {
   ],
   coverageThreshold: {
     global: {
-      branches: 80,
+      branches: 70,
       functions: 80,
       lines: 80,
       statements: 80,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,7 +29,7 @@ const config: Config.InitialOptions = {
   ],
   coverageThreshold: {
     global: {
-      branches: 70,
+      branches: 80,
       functions: 80,
       lines: 80,
       statements: 80,

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -21,7 +21,7 @@ import logger from '../utils/logger';
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 import { TFL_QUERY } from './queries/tflQuery';
 import { FeedName } from '../interfaces/FeedTypes';
-import { getItemFromS3, readOrCreateIfNotExists } from '../infrastructure/s3BucketService';
+import { readOrCreateIfNotExists } from '../infrastructure/s3BucketService';
 
 async function getTechnicalRecordDetails(
   technicalRecordQueryResult: TechnicalRecordQueryResult,

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -244,11 +244,20 @@ const getQueryMap: { [key in FeedName]: string } = {
   TFL: TFL_QUERY,
 };
 
+function getDateInQueryFormat(date: Date): string {
+  return `${date.getUTCDate()}/${date.getUTCMonth()}/${date.getUTCFullYear()} ${date.getUTCHours()}:${date.getUTCMinutes()}:${date.getUTCSeconds()}`;
+}
+
 async function getLastTFLFileDate(): Promise<string> {
   const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
-  const latestDate = await getItemFromS3(fileName);
-  const date = latestDate ? new Date(latestDate) : new Date();
-  return `${date.getUTCDate()}/${date.getUTCMonth()}/${date.getUTCFullYear()} ${date.getUTCHours()}:${date.getUTCMinutes()}:${date.getUTCSeconds()}`;
+  try {
+    const latestDate = await getItemFromS3(fileName);
+    const date = new Date(latestDate);
+    return getDateInQueryFormat(date);
+  } catch (err) {
+    logger.error(`Error reading the file: ${JSON.stringify(err)}`);
+    return getDateInQueryFormat(new Date());
+  }
 }
 
 async function getFeed(

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -21,6 +21,7 @@ import logger from '../utils/logger';
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 import { TFL_QUERY } from './queries/tflQuery';
 import { FeedName } from '../interfaces/FeedTypes';
+import { getLastAlphabeticalItemByPrefix } from '../infrastructure/s3BucketService';
 
 async function getTechnicalRecordDetails(
   technicalRecordQueryResult: TechnicalRecordQueryResult,
@@ -55,9 +56,9 @@ async function getVehicleDetails(vehicleDetailsQueryResult: QueryOutput, databas
   const vehicleDetailsResult = vehicleDetailsQueryResult[0][0] as VehicleQueryResult;
 
   if (
-    vehicleDetailsResult === undefined
-    || vehicleDetailsResult.id === undefined
-    || vehicleDetailsResult.result === undefined
+    vehicleDetailsResult === undefined ||
+    vehicleDetailsResult.id === undefined ||
+    vehicleDetailsResult.result === undefined
   ) {
     throw new NotFoundError('Vehicle was not found');
   }
@@ -136,9 +137,9 @@ async function getTestResultDetails(
   const testResultQueryResult = queryResult[0][0] as TestResultQueryResult;
 
   if (
-    testResultQueryResult === undefined
-    || testResultQueryResult.id === undefined
-    || testResultQueryResult.result === undefined
+    testResultQueryResult === undefined ||
+    testResultQueryResult.id === undefined ||
+    testResultQueryResult.result === undefined
   ) {
     throw new NotFoundError('Test not found');
   }
@@ -220,7 +221,8 @@ function getEvlFeedByVrmDetails(queryResult: QueryOutput): EvlFeedData {
 }
 
 function getFeedDetails(queryResult: QueryOutput, feedName: FeedName): EvlFeedData[] | TflFeedData[] {
-  const feedQueryResults: EvlFeedData[] | TflFeedData[] = feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
+  const feedQueryResults: EvlFeedData[] | TflFeedData[] =
+    feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
   if (feedQueryResults === undefined || feedQueryResults.length === 0) {
     throw new NotFoundError('No tests found');
   }
@@ -242,6 +244,12 @@ const getQueryMap: { [key in FeedName]: string } = {
   TFL: TFL_QUERY,
 };
 
+async function getLastTFLFileDate(): Promise<string> {
+  const lastDate = (await getLastAlphabeticalItemByPrefix('VOSA')).substring(5, 15);
+  logger.info(`File was last generated on ${lastDate}`);
+  return lastDate;
+}
+
 async function getFeed(
   databaseService: DatabaseServiceInterface,
   feedName: FeedName,
@@ -250,7 +258,8 @@ async function getFeed(
   // eslint-disable-next-line security/detect-object-injection
   const query = getQueryMap[feedName];
   logger.debug(`calling database with ${feedName} query ${query}`);
-  const queryResult = await databaseService.get(query, []);
+  const parameter = feedName === FeedName.TFL ? [await getLastTFLFileDate()] : [];
+  const queryResult = await databaseService.get(query, parameter);
   const result = getFeedDetails(queryResult, feedName);
   logger.debug(`result from database: ${JSON.stringify(result)}`);
   return result;

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -21,7 +21,7 @@ import logger from '../utils/logger';
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 import { TFL_QUERY } from './queries/tflQuery';
 import { FeedName } from '../interfaces/FeedTypes';
-import { getItemFromS3 } from '../infrastructure/s3BucketService';
+import { getItemFromS3, readOrCreateIfNotExists } from '../infrastructure/s3BucketService';
 
 async function getTechnicalRecordDetails(
   technicalRecordQueryResult: TechnicalRecordQueryResult,
@@ -250,14 +250,8 @@ function getDateInQueryFormat(date: Date): string {
 
 async function getLastTFLFileDate(): Promise<string> {
   const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
-  try {
-    const latestDate = await getItemFromS3(fileName);
-    const date = new Date(latestDate);
-    return getDateInQueryFormat(date);
-  } catch (err) {
-    logger.error(`Error reading the file: ${JSON.stringify(err)}`);
-    return getDateInQueryFormat(new Date());
-  }
+  const latestDate = await readOrCreateIfNotExists(fileName, new Date().toISOString());
+  return getDateInQueryFormat(new Date(latestDate));
 }
 
 async function getFeed(

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -21,7 +21,7 @@ import logger from '../utils/logger';
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 import { TFL_QUERY } from './queries/tflQuery';
 import { FeedName } from '../interfaces/FeedTypes';
-import { getLastAlphabeticalItemByPrefix } from '../infrastructure/s3BucketService';
+import { getItemFromS3 } from '../infrastructure/s3BucketService';
 
 async function getTechnicalRecordDetails(
   technicalRecordQueryResult: TechnicalRecordQueryResult,
@@ -245,9 +245,10 @@ const getQueryMap: { [key in FeedName]: string } = {
 };
 
 async function getLastTFLFileDate(): Promise<string> {
-  const lastDate = (await getLastAlphabeticalItemByPrefix('VOSA')).substring(5, 15);
-  logger.info(`File was last generated on ${lastDate}`);
-  return lastDate;
+  const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
+  const latestDate = await getItemFromS3(fileName);
+  const date = latestDate ? new Date(latestDate) : new Date();
+  return `${date.getUTCDate()}/${date.getUTCMonth()}/${date.getUTCFullYear()} ${date.getUTCHours()}:${date.getUTCMinutes()}:${date.getUTCSeconds()}`;
 }
 
 async function getFeed(

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -21,7 +21,7 @@ import logger from '../utils/logger';
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 import { TFL_QUERY } from './queries/tflQuery';
 import { FeedName } from '../interfaces/FeedTypes';
-import { readOrCreateIfNotExists } from '../infrastructure/s3BucketService';
+import { readAndUpsert } from '../infrastructure/s3BucketService';
 
 async function getTechnicalRecordDetails(
   technicalRecordQueryResult: TechnicalRecordQueryResult,
@@ -56,9 +56,9 @@ async function getVehicleDetails(vehicleDetailsQueryResult: QueryOutput, databas
   const vehicleDetailsResult = vehicleDetailsQueryResult[0][0] as VehicleQueryResult;
 
   if (
-    vehicleDetailsResult === undefined ||
-    vehicleDetailsResult.id === undefined ||
-    vehicleDetailsResult.result === undefined
+    vehicleDetailsResult === undefined
+    || vehicleDetailsResult.id === undefined
+    || vehicleDetailsResult.result === undefined
   ) {
     throw new NotFoundError('Vehicle was not found');
   }
@@ -137,9 +137,9 @@ async function getTestResultDetails(
   const testResultQueryResult = queryResult[0][0] as TestResultQueryResult;
 
   if (
-    testResultQueryResult === undefined ||
-    testResultQueryResult.id === undefined ||
-    testResultQueryResult.result === undefined
+    testResultQueryResult === undefined
+    || testResultQueryResult.id === undefined
+    || testResultQueryResult.result === undefined
   ) {
     throw new NotFoundError('Test not found');
   }
@@ -221,8 +221,7 @@ function getEvlFeedByVrmDetails(queryResult: QueryOutput): EvlFeedData {
 }
 
 function getFeedDetails(queryResult: QueryOutput, feedName: FeedName): EvlFeedData[] | TflFeedData[] {
-  const feedQueryResults: EvlFeedData[] | TflFeedData[] =
-    feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
+  const feedQueryResults: EvlFeedData[] | TflFeedData[] = feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
   if (feedQueryResults === undefined || feedQueryResults.length === 0) {
     throw new NotFoundError('No tests found');
   }
@@ -250,7 +249,7 @@ function getDateInQueryFormat(date: Date): string {
 
 async function getLastTFLFileDate(): Promise<string> {
   const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
-  const latestDate = await readOrCreateIfNotExists(fileName, new Date().toISOString());
+  const latestDate = await readAndUpsert(fileName, new Date().toISOString());
   return getDateInQueryFormat(new Date(latestDate));
 }
 

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -56,9 +56,9 @@ async function getVehicleDetails(vehicleDetailsQueryResult: QueryOutput, databas
   const vehicleDetailsResult = vehicleDetailsQueryResult[0][0] as VehicleQueryResult;
 
   if (
-    vehicleDetailsResult === undefined
-    || vehicleDetailsResult.id === undefined
-    || vehicleDetailsResult.result === undefined
+    vehicleDetailsResult === undefined ||
+    vehicleDetailsResult.id === undefined ||
+    vehicleDetailsResult.result === undefined
   ) {
     throw new NotFoundError('Vehicle was not found');
   }
@@ -137,9 +137,9 @@ async function getTestResultDetails(
   const testResultQueryResult = queryResult[0][0] as TestResultQueryResult;
 
   if (
-    testResultQueryResult === undefined
-    || testResultQueryResult.id === undefined
-    || testResultQueryResult.result === undefined
+    testResultQueryResult === undefined ||
+    testResultQueryResult.id === undefined ||
+    testResultQueryResult.result === undefined
   ) {
     throw new NotFoundError('Test not found');
   }
@@ -221,7 +221,8 @@ function getEvlFeedByVrmDetails(queryResult: QueryOutput): EvlFeedData {
 }
 
 function getFeedDetails(queryResult: QueryOutput, feedName: FeedName): EvlFeedData[] | TflFeedData[] {
-  const feedQueryResults: EvlFeedData[] | TflFeedData[] = feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
+  const feedQueryResults: EvlFeedData[] | TflFeedData[] =
+    feedName === FeedName.EVL ? (queryResult[0][1] as EvlFeedData[]) : (queryResult[0] as TflFeedData[]);
   if (feedQueryResults === undefined || feedQueryResults.length === 0) {
     throw new NotFoundError('No tests found');
   }
@@ -243,14 +244,13 @@ const getQueryMap: { [key in FeedName]: string } = {
   TFL: TFL_QUERY,
 };
 
-function getDateInQueryFormat(date: Date): string {
-  return `${date.getUTCDate()}/${date.getUTCMonth()}/${date.getUTCFullYear()} ${date.getUTCHours()}:${date.getUTCMinutes()}:${date.getUTCSeconds()}`;
-}
-
 async function getLastTFLFileDate(): Promise<string> {
   const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
   const latestDate = await readAndUpsert(fileName, new Date().toISOString());
-  return getDateInQueryFormat(new Date(latestDate));
+  const date = new Date(latestDate);
+  return `${date.getUTCDate()}/${
+    date.getUTCMonth() + 1
+  }/${date.getUTCFullYear()} ${date.getUTCHours()}:${date.getUTCMinutes()}:${date.getUTCSeconds()}`;
 }
 
 async function getFeed(

--- a/src/app/databaseService.ts
+++ b/src/app/databaseService.ts
@@ -246,7 +246,9 @@ const getQueryMap: { [key in FeedName]: string } = {
 
 async function getLastTFLFileDate(): Promise<string> {
   const fileName = 'TFL_LATEST_VALID_FROM_DATE.txt';
-  const latestDate = await readAndUpsert(fileName, new Date().toISOString());
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setUTCDate(new Date().getUTCDate() - 7);
+  const latestDate = await readAndUpsert(fileName, new Date().toISOString(), oneWeekAgo.toISOString());
   const date = new Date(latestDate);
   return `${date.getUTCDate()}/${
     date.getUTCMonth() + 1

--- a/src/app/queries/tflQuery.ts
+++ b/src/app/queries/tflQuery.ts
@@ -11,4 +11,5 @@ SELECT
     IssuedBy,
     IssueDate
 FROM tfl_view
-WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s');`;
+WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s')
+ORDER BY IssueDate ASC;`;

--- a/src/app/queries/tflQuery.ts
+++ b/src/app/queries/tflQuery.ts
@@ -10,5 +10,5 @@ SELECT
     ExpiryDate,
     IssuedBy,
     IssueDate
-WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s');
-`;
+FROM tfl_view
+WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s');`;

--- a/src/app/queries/tflQuery.ts
+++ b/src/app/queries/tflQuery.ts
@@ -1,2 +1,14 @@
-export const TFL_QUERY = 'SELECT `v`.`vrm_trm`, `v`.`vin`, `c`.`certificateNumber`, `c`.`modificationTypeUsed`, `c`.`testStatus`, `c`.`fuel_emission_id`,`c`.`createdAt`, `c`.`lastUpdatedAt`, `c`.`createdBy_Id`, `c`.`firstUseDate` FROM `vehicle` `v`, `test_result` `c` LIMIT 100;';
-// TODO: This is totally wrong and needs updating when data have completed the work for this query
+export const TFL_QUERY = `
+SELECT 
+    VRM,
+    VIN,
+    SerialNumberOfCertificate,
+    CertificationModificationType,
+    TestStatus,
+    PMEuropeanEmissionClassificationCode,
+    ValidFromDate,
+    ExpiryDate,
+    IssuedBy,
+    IssueDate
+WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s');
+`;

--- a/src/app/testResultsQueryFunctionFactory.ts
+++ b/src/app/testResultsQueryFunctionFactory.ts
@@ -10,7 +10,8 @@ import TestResult from '../interfaces/queryResults/test/testResult';
 
 export default (
   event: ResultsEvent,
-): ((databaseService: DatabaseService, event: ResultsEvent) => Promise<TestResult[]>) => {
+): ((databaseService: DatabaseService, event: ResultsEvent) => Promise<TestResult[]>
+  ) => {
   if (event.vinNumber) {
     console.info('Using getTestResultsByVin');
 

--- a/src/app/testResultsQueryFunctionFactory.ts
+++ b/src/app/testResultsQueryFunctionFactory.ts
@@ -1,14 +1,16 @@
 import DatabaseService from '../interfaces/DatabaseService';
 import ResultsEvent from '../interfaces/ResultsEvent';
 import {
-  getTestResultsByVrm, getTestResultsByVin, getTestResultsByTrailerId, getTestResultsByTestId,
+  getTestResultsByVrm,
+  getTestResultsByVin,
+  getTestResultsByTrailerId,
+  getTestResultsByTestId,
 } from './databaseService';
 import TestResult from '../interfaces/queryResults/test/testResult';
 
 export default (
   event: ResultsEvent,
-): ((databaseService: DatabaseService, event: ResultsEvent) => Promise<TestResult[]>
-  ) => {
+): ((databaseService: DatabaseService, event: ResultsEvent) => Promise<TestResult[]>) => {
   if (event.vinNumber) {
     console.info('Using getTestResultsByVin');
 

--- a/src/infrastructure/databaseService.ts
+++ b/src/infrastructure/databaseService.ts
@@ -9,7 +9,7 @@ export default class DatabaseService implements DatabaseServiceInterface {
 
   async get(query: string, params: string[] | undefined): Promise<[RowDataPacket[], FieldPacket[]]> {
     try {
-      console.info(`Executing query ${query} with params ${params.join(', ')}`);
+      console.info(`Executing query ${query} with params ${params?.join(', ')}`);
       const tempResult = await this.pool.query(query, params);
       return tempResult as [RowDataPacket[], FieldPacket[]];
     } catch (e) {
@@ -24,13 +24,13 @@ export default class DatabaseService implements DatabaseServiceInterface {
 
   pool: mysqlp.Pool;
 
-  static pool: mysqlp.Pool = undefined;
+  static pool: mysqlp.Pool | undefined = undefined;
 
   public static async build(
     secretsManager: SecretsManagerServiceInterface,
     mysql: typeof mysqlp,
   ): Promise<DatabaseServiceInterface> {
-    const dbConnectionDetailsString = await secretsManager.getSecret(process.env.SECRET);
+    const dbConnectionDetailsString = await secretsManager.getSecret(process.env.SECRET ?? '');
     const dbConnectionDetails = JSON.parse(dbConnectionDetailsString) as StoredConnectionDetails;
     if (this.pool === undefined) {
       this.pool = mysql.createPool(<mysqlp.PoolOptions>{

--- a/src/infrastructure/s3BucketService.ts
+++ b/src/infrastructure/s3BucketService.ts
@@ -24,7 +24,7 @@ export async function getItemFromS3(key: string): Promise<string> {
     return body;
   } catch (err) {
     logger.error(`Error reading file from S3 ${JSON.stringify(err)}`);
-    throw new Error(err);
+    throw err;
   }
 }
 

--- a/src/infrastructure/s3BucketService.ts
+++ b/src/infrastructure/s3BucketService.ts
@@ -14,22 +14,11 @@ export function uploadToS3(processedData: string, fileName: string, callback: ()
   });
 }
 
-export async function getLastAlphabeticalItemByPrefix(prefix: string): Promise<string> {
-  logger.info(`Getting latest file uploaded for prefix ${prefix}`);
+export async function getItemFromS3(key: string): Promise<string> {
+  logger.info(`Reading contents of file ${key}`);
   const s3 = configureS3();
-  const params: AWS.S3.ListObjectsV2Request = { Bucket: process.env.AWS_S3_BUCKET_NAME, Prefix: prefix };
-  return getByPrefix(s3, params);
-}
-
-async function getByPrefix(s3: AWS.S3, params: AWS.S3.ListObjectsV2Request, allItems: string[] = []): Promise<string> {
-  const response = await s3.listObjectsV2(params).promise();
-  response.Contents.forEach((item) => allItems.push(item.Key));
-  if (response.NextContinuationToken) {
-    params.ContinuationToken = response.NextContinuationToken;
-    await getByPrefix(s3, params, allItems);
-  }
-  allItems.reverse();
-  return allItems[0];
+  const params: AWS.S3.GetObjectRequest = { Bucket: process.env.AWS_S3_BUCKET_NAME, Key: key };
+  return (await s3.getObject(params).promise()).Body.toString();
 }
 
 function configureS3() {

--- a/src/infrastructure/s3BucketService.ts
+++ b/src/infrastructure/s3BucketService.ts
@@ -18,7 +18,9 @@ export async function getItemFromS3(key: string): Promise<string> {
   logger.info(`Reading contents of file ${key}`);
   const s3 = configureS3();
   const params: AWS.S3.GetObjectRequest = { Bucket: process.env.AWS_S3_BUCKET_NAME, Key: key };
-  return (await s3.getObject(params).promise()).Body.toString();
+  const body = (await s3.getObject(params).promise()).Body.toString();
+  logger.info(`File contents retrieved: ${body}`);
+  return body;
 }
 
 function configureS3() {

--- a/src/infrastructure/s3BucketService.ts
+++ b/src/infrastructure/s3BucketService.ts
@@ -14,6 +14,24 @@ export function uploadToS3(processedData: string, fileName: string, callback: ()
   });
 }
 
+export async function getLastAlphabeticalItemByPrefix(prefix: string): Promise<string> {
+  logger.info(`Getting latest file uploaded for prefix ${prefix}`);
+  const s3 = configureS3();
+  const params: AWS.S3.ListObjectsV2Request = { Bucket: process.env.AWS_S3_BUCKET_NAME, Prefix: prefix };
+  return getByPrefix(s3, params);
+}
+
+async function getByPrefix(s3: AWS.S3, params: AWS.S3.ListObjectsV2Request, allItems: string[] = []): Promise<string> {
+  const response = await s3.listObjectsV2(params).promise();
+  response.Contents.forEach((item) => allItems.push(item.Key));
+  if (response.NextContinuationToken) {
+    params.ContinuationToken = response.NextContinuationToken;
+    await getByPrefix(s3, params, allItems);
+  }
+  allItems.reverse();
+  return allItems[0];
+}
+
 function configureS3() {
   if (process.env.IS_OFFLINE === 'true') {
     logger.debug('configuring s3 using serverless');

--- a/src/utils/tflHelpers.ts
+++ b/src/utils/tflHelpers.ts
@@ -1,7 +1,10 @@
 import TflFeedData from '../interfaces/queryResults/tflFeedData';
 
 export function processTFLFeedData(data: TflFeedData): TflFeedData {
-  return Object.assign({}, ...Object.keys(data).map((key) => ({ [key]: escapeString(data[key]) }))) as TflFeedData;
+  return Object.assign(
+    {},
+    ...Object.keys(data).map((key) => ({ [key]: escapeString(data[key as keyof TflFeedData]) })),
+  ) as TflFeedData;
 }
 
 export function escapeString(str: any): string {

--- a/tests/unit/app/databaseService.test.ts
+++ b/tests/unit/app/databaseService.test.ts
@@ -155,13 +155,13 @@ describe('Database Service', () => {
       expect(result.technicalrecords).toHaveLength(1);
       expect(result.technicalrecords[0].functionCode).toEqual('Test tech record');
       expect(result.technicalrecords[0].psvBrakes).toHaveLength(2);
-      expect(result.technicalrecords[0].psvBrakes[0].brakeCode).toEqual('Test brakes');
+      expect(result.technicalrecords?.[0].psvBrakes?.[0].brakeCode).toEqual('Test brakes');
       expect(result.technicalrecords[0].axles).toHaveLength(2);
-      expect(result.technicalrecords[0].axles[0].axleNumber).toEqual(1);
+      expect(result.technicalrecords?.[0].axles?.[0].axleNumber).toEqual(1);
       expect(result.technicalrecords[0].axlespacing).toHaveLength(2);
-      expect(result.technicalrecords[0].axlespacing[0].axles).toEqual('Test axle spacing');
+      expect(result.technicalrecords?.[0].axlespacing?.[0].axles).toEqual('Test axle spacing');
       expect(result.technicalrecords[0].plates).toHaveLength(2);
-      expect(result.technicalrecords[0].plates[0].plateSerialNumber).toEqual('Test plate');
+      expect(result.technicalrecords?.[0].plates?.[0].plateSerialNumber).toEqual('Test plate');
     });
 
     it('defaults to an empty array if nothing is returned by the subqueries', async () => {
@@ -364,8 +364,8 @@ describe('Database Service', () => {
       expect(response).toHaveLength(2);
       expect(response[0].customDefect).toHaveLength(2);
       expect(response[0].defects).toHaveLength(2);
-      expect(response[0].customDefect[0].defectName).toEqual('Custom defect');
-      expect(response[0].defects[1].defect.imDescription).toEqual('Test defect 2');
+      expect(response[0].customDefect?.[0].defectName).toEqual('Custom defect');
+      expect(response[0].defects?.[1].defect?.imDescription).toEqual('Test defect 2');
     });
   });
 });

--- a/tests/unit/handler.test.ts
+++ b/tests/unit/handler.test.ts
@@ -5,8 +5,8 @@ import Version from '../../local/data/version.json';
 
 describe('Application entry', () => {
   const OLD_ENV = process.env;
-  let event;
-  let context;
+  let event: any;
+  let context: any;
   let majorVersionNumber: string;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('Application entry', () => {
           event = { httpMethod: 'GET', path: '/v1/enquiry/' };
 
           const response = await handler(event, context);
-          const parsedBody = JSON.parse(response.body) as { ok: boolean };
+          const parsedBody = JSON.parse(response.body ?? '') as { ok: boolean };
 
           expect(parsedBody.ok).toBe(true);
         });
@@ -65,7 +65,7 @@ describe('Application entry', () => {
           };
 
           const response = await handler(event, context);
-          const parsedResponse = JSON.parse(response.body) as { version: string };
+          const parsedResponse = JSON.parse(response.body ?? '') as { version: string };
           // is given when we build the file as API_VERSION from package.json with $npm_package_version
           // TODO we follow semver for code versioning ATM and only use the major for the API endpoint as v1
           const { API_VERSION } = process.env;

--- a/tests/unit/infrastructure/s3BucketService.test.ts
+++ b/tests/unit/infrastructure/s3BucketService.test.ts
@@ -36,11 +36,12 @@ describe('readAndUpsert', () => {
   it.each([404, 403])('it should create a new file the the content and return the new content', async (statusCode) => {
     const fileName = 'a_file_with_a_date.txt';
     const newFileContents = 'new content for the file';
+    const valueIfNotFound = 'a week ago';
 
     mockPromise.mockRejectedValueOnce({ statusCode });
 
-    const contents = await readAndUpsert(fileName, newFileContents);
-    expect(contents).toEqual(newFileContents);
+    const contents = await readAndUpsert(fileName, newFileContents, valueIfNotFound);
+    expect(contents).toEqual(valueIfNotFound);
     expect(mockUpload).toHaveBeenCalledWith(
       expect.objectContaining({ Key: fileName, Body: newFileContents }),
       expect.anything(),

--- a/tests/unit/infrastructure/s3BucketService.test.ts
+++ b/tests/unit/infrastructure/s3BucketService.test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable import/first */
+process.env.LOG_LEVEL = 'error';
+const mockPromise = jest.fn();
+const mockGetObject = jest.fn(() => ({
+  promise: mockPromise,
+}));
+const mockUpload = jest.fn();
+const mockS3 = jest.fn(() => ({
+  upload: mockUpload,
+  getObject: mockGetObject,
+}));
+import { readAndUpsert } from '../../../src/infrastructure/s3BucketService';
+
+jest.mock('aws-sdk', () => ({
+  S3: mockS3,
+}));
+
+describe('readAndUpsert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should read the file, return the value in the file and update the stored value', async () => {
+    const fileName = 'a_file_with_a_date.txt';
+    const originalFileContents = 'the original content of the file';
+    const newFileContents = 'new content for the file';
+
+    mockPromise.mockResolvedValueOnce({ Body: Buffer.from(originalFileContents) });
+
+    const contents = await readAndUpsert(fileName, newFileContents);
+    expect(contents).toEqual(originalFileContents);
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ Key: fileName, Body: newFileContents }),
+      expect.anything(),
+    );
+  });
+  it.each([404, 403])('it should create a new file the the content and return the new content', async (statusCode) => {
+    const fileName = 'a_file_with_a_date.txt';
+    const newFileContents = 'new content for the file';
+
+    mockPromise.mockRejectedValueOnce({ statusCode });
+
+    const contents = await readAndUpsert(fileName, newFileContents);
+    expect(contents).toEqual(newFileContents);
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ Key: fileName, Body: newFileContents }),
+      expect.anything(),
+    );
+  });
+});

--- a/tests/unit/infrastructure/secretsManagerService.test.ts
+++ b/tests/unit/infrastructure/secretsManagerService.test.ts
@@ -11,14 +11,14 @@ describe('Secrets service', () => {
       throw new Error('Error');
     });
 
-    await expect(service.getSecret(undefined)).rejects.toThrow(Error);
+    await expect(service.getSecret((undefined as unknown) as string)).rejects.toThrow(Error);
   });
 
   it('throws an error when the secretName is undefined', async () => {
     const mockSecretsManager = ({} as unknown) as SecretsManager;
     const service = new SecretsManagerService(mockSecretsManager);
 
-    await expect(service.getSecret(undefined)).rejects.toThrow(Error);
+    await expect(service.getSecret((undefined as unknown) as string)).rejects.toThrow(Error);
   });
 
   it('should return the secret string', async () => {

--- a/tests/unit/resources/localDatabase.test.ts
+++ b/tests/unit/resources/localDatabase.test.ts
@@ -43,8 +43,8 @@ describe('Local database', () => {
     localDatabase();
 
     expect(mockedSpawnSync).toHaveBeenCalledTimes(2);
-    expect(mockedSpawnSync.mock.calls[1][1][0]).toEqual('start');
-    expect(mockedSpawnSync.mock.calls[1][1][1]).toEqual(containerName);
+    expect(mockedSpawnSync.mock.calls[1][1]?.[0]).toEqual('start');
+    expect(mockedSpawnSync.mock.calls[1][1]?.[1]).toEqual(containerName);
   });
 
   it('boots the DB from scratch when it does not exist', () => {
@@ -71,7 +71,7 @@ describe('Local database', () => {
 
     expect(mockedSpawnSync).toHaveBeenCalledTimes(3);
     expect(mockedSpawnSync.mock.calls[1][0]).toEqual('docker');
-    expect(mockedSpawnSync.mock.calls[1][1][0]).toEqual('run');
+    expect(mockedSpawnSync.mock.calls[1][1]?.[0]).toEqual('run');
     expect(mockedSpawnSync.mock.calls[2][0]).toContain('liquibase');
   });
 

--- a/tests/unit/utils/index.test.ts
+++ b/tests/unit/utils/index.test.ts
@@ -1,9 +1,9 @@
 import { createMajorVersionNumber, createHandlerBasePath } from '../../../src/utils';
 
 describe("'Utils' file", () => {
-  let SEMVER_VERSION_NUMBER;
-  let expectedVersionNumber;
-  let expectedBasePath;
+  let SEMVER_VERSION_NUMBER: string;
+  let expectedVersionNumber: string;
+  let expectedBasePath: string;
 
   beforeEach(() => {
     SEMVER_VERSION_NUMBER = '1.0.0';


### PR DESCRIPTION
## Update enquiry service to use TFL view

Update to the service to use the newly created TFL view. The service also now stores the last time the query was ran in a file in the bucket, in order to only send relevant data. It will also create the file using the current date and time if it does not exist.

## Testing
Storing the value of the last time the query was ran as `2023/04/23 06:05:35` in the file results in 29 rows returned (against develop env NOP). This is denoted in the name of the file saved to s3.
![CB2-8313](https://github.com/dvsa/cvs-svc-enquiry/assets/104442665/69f14b8f-27ff-42a1-8551-7aa83c09e47d)
Manually running the same query against NOP develop also returns 29 rows.
![CB2-8313 query on develop](https://github.com/dvsa/cvs-svc-enquiry/assets/104442665/3857b084-0790-4e15-afa4-78fa6bf318e9)

[CB2-8313](https://dvsa.atlassian.net/browse/CB2-8313)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number