### PR TITLE
fix(cb2-8485): allow 24hr format for TFL

### DIFF
--- a/src/app/queries/tflQuery.ts
+++ b/src/app/queries/tflQuery.ts
@@ -11,5 +11,5 @@ SELECT
     IssuedBy,
     IssueDate
 FROM tfl_view
-WHERE ValidFromDate >= STR_TO_DATE(?, '%d/%m/%Y %h:%i:%s')
-ORDER BY IssueDate ASC;`;
+WHERE IssueDateTime >= STR_TO_DATE(?, '%d/%m/%Y %T')
+ORDER BY IssueDateTime ASC;`;


### PR DESCRIPTION
## tfl view does not return any vehicles if time of the lambda execution is after 12 noon

- Format the date to allow 24hr format
- Use the `IssueDateTime` in the where and orderby 

[CB2-8485](https://dvsa.atlassian.net/browse/CB2-8485)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number